### PR TITLE
refactor: implement filesystem operations in nushell

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,23 @@
 
 Call `sudo` in yazi.
 
+## Requirements
+
+- [nushell](https://github.com/nushell/nushell)
+
 ## Functions
 
 - [x] copy files
 - [x] move files
 - [x] rename file
-- [x] trash files (using [conceal](https://github.com/TD-Sky/conceal))
+- [x] trash files
 - [x] remove files
 - [x] create absolute-path symbolic links
-- [ ] create relative-path symbolic links
+- [x] create relative-path symbolic links
 - [x] touch new file
 - [x] make new directory
+
+> You can use [conceal](https://github.com/TD-Sky/conceal) to browse and restore trashed files
 
 ## Usage
 
@@ -21,8 +27,14 @@ Here are my own keymap for reference only:
 ```toml
 # sudo cp/mv
 [[manager.keymap]]
-on = ["R", "p"]
+on = ["R", "p", "p"]
 run = "plugin sudo --args='paste'"
+desc = "sudo paste"
+
+# sudo cp/mv --force
+[[manager.keymap]]
+on = ["R", "P"]
+run = "plugin sudo --args='paste -f'"
 desc = "sudo paste"
 
 # sudo mv
@@ -33,9 +45,15 @@ desc = "sudo rename"
 
 # sudo ln -s (absolute-path)
 [[manager.keymap]]
-on = ["R", "l"]
+on = ["R", "p", "l"]
 run = "plugin sudo --args='link'"
 desc = "sudo link"
+
+# sudo ln -s (relative-path)
+[[manager.keymap]]
+on = ["R", "p", "L"]
+run = "plugin sudo --args='link -r'"
+desc = "sudo link relative path"
 
 # sudo touch/mkdir
 [[manager.keymap]]

--- a/fs.nu
+++ b/fs.nu
@@ -1,0 +1,145 @@
+#!/usr/bin/env nu
+
+def main [] {}
+
+def 'main cp' [
+    --force,
+    ...paths: path,
+] {
+    let _ = $paths
+    | zip {
+        $paths
+        | each {|p|
+            if $force {
+                './'
+            } else {
+                $p
+                | path basename
+                | legit_name
+            }
+        }
+    }
+    | each {|it|
+        cp -rfv $it.0 $it.1
+    }
+}
+
+def 'main mv' [
+    --force,
+    ...paths: path,
+] {
+    let _ = $paths
+    | zip {
+        $paths
+        | each {|p|
+            if $force {
+                './'
+            } else {
+                $p
+                | path basename
+                | legit_name
+            }
+        }
+    }
+    | each {|it|
+        mv -v $it.0 $it.1
+    }
+}
+
+def 'main ln' [
+    --relative,
+    ...paths: path,
+] {
+    let _ = $paths
+    | zip {
+        $paths
+        | each {|p| $p | path basename | legit_name }
+    }
+    | each {|it|
+        let src = if $relative {
+            $it.0 | relative-to-cwd
+        } else {
+            $it.0
+        }
+
+        ln -s -v $src $it.1
+    }
+}
+
+def 'main rm' [
+    --permanent,
+    ...paths: path,
+] {
+    let f = if $permanent {
+        {|path| rm -r --permanent $path }
+    } else {
+        {|path| rm -r --trash $path }
+    }
+
+    for path in $paths {
+        do $f $path
+    }
+}
+
+# Find a legit file name for renaming
+def legit_name [] -> string {
+    let name = $in
+    mut new_name = $name
+    for i in 1.. {
+        if not ($new_name | path exists) {
+            return $new_name
+        }
+        $new_name = $"($name)_($i)"
+    }
+}
+
+def relative-to-cwd [] -> string {
+    let path = $in
+
+    let path_cmps = $path | path split
+    let path_len = $path_cmps | length
+    let cwd_cmps = pwd | path split
+
+    let i = $path_cmps
+        | zip $cwd_cmps
+        | position {|it| $it.0 != $it.1 }
+
+    if $i != null {
+        '..'
+        | repeat ($path_len - $i)
+        | path join (
+            $path_cmps
+                | range $i..
+                | path join
+        )
+    } else {
+        let count = ($cwd_cmps | length) - $path_len
+
+        if $count > 0 {
+            '..' | repeat $count | path join
+        } else if $count == 0 {
+            '.'
+        } else {
+            $path_cmps | range $count.. | path join
+        }
+    }
+}
+
+def position [predicate: closure] -> int {
+    let iter = $in
+
+    for e in ($iter | enumerate) {
+        if (do $predicate $e.item) {
+            return $e.index
+        }
+    }
+}
+
+def repeat [n: int] -> list {
+    let elt = $in
+
+    0..<$n
+    | reduce --fold [] {|_, list|
+        $list | append $elt
+    }
+}


### PR DESCRIPTION
It has become difficult to implement more complex functionality through calling `sudo` with simple shell commands,
so I write nushell script as the called program for `sudo`, which brings much functionalities hard to resolved in yazi lua runtime
(I cannot use lualocks to develop yazi plugin):

- Smart destination name when pasting
- Relative path linking

---

However, there is a bug in yazi. The visual mode selected files aren't be count as selected files,
so sudo.yazi cannot delete visual mode selected files.