### PR TITLE
feat: add bulk rename via editor

### DIFF
--- a/assets/fs.nu
+++ b/assets/fs.nu
@@ -90,6 +90,59 @@ def 'main rm' [
     }
 }
 
+
+def 'str split-once' []: string -> list {
+    let s = $in
+
+    let i = $s
+    | split chars
+    | iter find-index {|c| $c == '.' }
+
+    if $i >= 0 {
+        [
+            ($s | str substring ..<$i),
+            ($s | str substring ($i + 1)..),
+        ]
+    } else {
+        null
+    }
+}
+
+# Read a temp file with edited names and rename corresponding paths.
+# Called via: sudo -k -- nu fs.nu bulk-rename --root <root> --tmp <tmp> <paths...>
+def 'main bulk-rename' [
+    --root: string,       # common root directory
+    --tmp: string,        # temp file with one new name per line
+    ...paths: path,       # original full paths
+] {
+    let old_names = if $root == "" {
+        $paths
+    } else {
+        let prefix = $"($root)/"
+        $paths | each {|p| $p | str replace $prefix '' }
+    }
+
+    let new_names = (open $tmp | lines)
+    rm --force $tmp
+
+    let count = ($paths | length)
+    for i in 0..($count - 1) {
+        if $i >= ($new_names | length) {
+            break
+        }
+        let old_rel = $old_names | get $i
+        let new_rel = $new_names | get $i
+        if ($new_rel != null) and ($new_rel != "") and ($new_rel != $old_rel) {
+            let new_path = if $root == "" {
+                $new_rel
+            } else {
+                $"($root)/($new_rel)"
+            }
+            mv -v ($paths | get $i) $new_path
+        }
+    }
+}
+
 # Find a legit file name for renaming
 def legit_name []: string -> string {
     let name = $in
@@ -107,21 +160,4 @@ def legit_name []: string -> string {
     }
 
     return null
-}
-
-def 'str split-once' []: string -> list {
-    let s = $in
-
-    let i = $s
-    | split chars
-    | iter find-index {|c| $c == '.' }
-
-    if $i >= 0 {
-        [
-            ($s | str substring ..<$i),
-            ($s | str substring ($i + 1)..),
-        ]
-    } else {
-        null
-    }
 }

--- a/assets/fs.nu
+++ b/assets/fs.nu
@@ -108,14 +108,14 @@ def 'str split-once' []: string -> list {
     }
 }
 
-# Create a temp file with old names, open editor, then sudo-mv.
-# Called via: SUDO_YAZI_EDITOR_CMD='...' nu fs.nu bulk-rename --root <root> <paths...>
-def 'main bulk-rename' [
+# Write old names to result file and open editor on it.
+# Called via: nu fs.nu bulk-rename-edit --root <root> --editor-cmd <cmd> --result-file <file> <paths...>
+def 'main bulk-rename-edit' [
     --root: string,          # common root directory
     --editor-cmd: string,    # editor command with %s placeholder
+    --result-file: string,   # file to write old names into and edit
     ...paths: path,          # original full paths
 ] {
-    let editor_cmd = $editor_cmd
     let old_names = if $root == "" {
         $paths
     } else {
@@ -123,20 +123,30 @@ def 'main bulk-rename' [
         $paths | each {|p| $p | str replace $prefix '' }
     }
 
-    let tmp = (mktemp -t sudo-yazi-XXXXXX)
+    $old_names | str join (char newline) | save -f $result_file
 
-    $old_names | str join (char newline) | save -f $tmp
-
-    let words = ($editor_cmd | str replace '%s' $tmp | split row ' ')
+    let words = ($editor_cmd | str replace '%s' $result_file | split row ' ')
     if ($words | length) > 0 {
         run-external ...$words
     }
+}
 
-    let new_names = (open $tmp | lines)
-    rm --force $tmp
+# Read edited names from result file and sudo-mv old paths to new paths.
+# Called via: sudo -k -- nu fs.nu bulk-rename-do --root <root> --result-file <file> <paths...>
+def 'main bulk-rename-do' [
+    --root: string,        # common root directory
+    --result-file: string, # file with edited names (one per line)
+    ...paths: path,        # original full paths
+] {
+    let new_names = (open $result_file | lines)
+    rm --force $result_file
 
-    ^sudo -k
-    ^sudo -v
+    let old_names = if $root == "" {
+        $paths
+    } else {
+        let prefix = $"($root)/"
+        $paths | each {|p| $p | str replace $prefix '' }
+    }
 
     let count = ($paths | length)
     for i in 0..($count - 1) {
@@ -151,11 +161,9 @@ def 'main bulk-rename' [
             } else {
                 $"($root)/($new_rel)"
             }
-            ^sudo mv -v ($paths | get $i) $new_path
+            mv -v ($paths | get $i) $new_path
         }
     }
-
-    ^sudo -k
 }
 
 # Find a legit file name for renaming

--- a/assets/fs.nu
+++ b/assets/fs.nu
@@ -108,13 +108,14 @@ def 'str split-once' []: string -> list {
     }
 }
 
-# Read a temp file with edited names and rename corresponding paths.
-# Called via: sudo -k -- nu fs.nu bulk-rename --root <root> --tmp <tmp> <paths...>
+# Create a temp file with old names, open editor, then sudo-mv.
+# Called via: SUDO_YAZI_EDITOR_CMD='...' nu fs.nu bulk-rename --root <root> <paths...>
 def 'main bulk-rename' [
-    --root: string,       # common root directory
-    --tmp: string,        # temp file with one new name per line
-    ...paths: path,       # original full paths
+    --root: string,          # common root directory
+    --editor-cmd: string,    # editor command with %s placeholder
+    ...paths: path,          # original full paths
 ] {
+    let editor_cmd = $editor_cmd
     let old_names = if $root == "" {
         $paths
     } else {
@@ -122,8 +123,20 @@ def 'main bulk-rename' [
         $paths | each {|p| $p | str replace $prefix '' }
     }
 
+    let tmp = (mktemp -t sudo-yazi-XXXXXX)
+
+    $old_names | str join (char newline) | save -f $tmp
+
+    let words = ($editor_cmd | str replace '%s' $tmp | split row ' ')
+    if ($words | length) > 0 {
+        run-external ...$words
+    }
+
     let new_names = (open $tmp | lines)
     rm --force $tmp
+
+    ^sudo -k
+    ^sudo -v
 
     let count = ($paths | length)
     for i in 0..($count - 1) {
@@ -138,9 +151,11 @@ def 'main bulk-rename' [
             } else {
                 $"($root)/($new_rel)"
             }
-            mv -v ($paths | get $i) $new_path
+            ^sudo mv -v ($paths | get $i) $new_path
         }
     }
+
+    ^sudo -k
 }
 
 # Find a legit file name for renaming

--- a/main.lua
+++ b/main.lua
@@ -267,9 +267,24 @@ local function sudo_bulk_rename(value)
 
     local editor_escaped = editor_cmd:gsub("%%s", "%%%%s")
 
-    local args = { "nu", fs, "bulk-rename", "--root", root, "--editor-cmd", ya.quote(editor_escaped) }
-    extend_iter(args, list_map(selected, ya.quote))
-    execute(args)
+    local edit_args = { "nu", fs, "bulk-rename-edit", "--root", root, "--editor-cmd", ya.quote(editor_escaped), "--result-file", "$RESULT_TMP" }
+    extend_iter(edit_args, list_map(selected, ya.quote))
+
+    local do_args = sudo_cmd()
+    extend_list(do_args, { "nu", fs, "bulk-rename-do", "--root", root, "--result-file", "$RESULT_TMP" })
+    extend_iter(do_args, list_map(selected, ya.quote))
+
+    local script = "RESULT_TMP=$(mktemp)\n"
+        .. table.concat(edit_args, " ") .. "\n"
+        .. "if [ -s \"$RESULT_TMP\" ]; then\n"
+        .. "    " .. table.concat(do_args, " ") .. "\n"
+        .. "fi\n"
+
+    ya.emit("shell", {
+        script,
+        block = true,
+        confirm = true,
+    })
 end
 
 local function sudo_remove(value)

--- a/main.lua
+++ b/main.lua
@@ -122,24 +122,10 @@ local get_state = ya.sync(function(_, cmd)
             for _, url in pairs(cx.active.selected) do
                 table.insert(selected, tostring(url))
             end
-
-            local editor_cmd = nil
-            local oe = rt and rt.opener and rt.opener.edit
-            if oe then
-                for _, rule in ipairs(oe) do
-                    if rule.block then
-                        editor_cmd = rule.run
-                        break
-                    end
-                end
-            end
-            editor_cmd = editor_cmd or "${EDITOR:-vim} %s"
-
             return {
                 kind = "bulk_rename",
                 value = {
                     selected = selected,
-                    editor_cmd = editor_cmd,
                 },
             }
         end
@@ -266,7 +252,18 @@ end
 local function sudo_bulk_rename(value)
     local selected = value.selected
     local root = common_prefix(selected)
-    local editor_cmd = value.editor_cmd
+
+    local editor_cmd = nil
+    local oe = rt and rt.opener and rt.opener.edit
+    if oe then
+        for _, rule in pairs(oe:match()) do
+            if rule.block then
+                editor_cmd = rule.run
+                break
+            end
+        end
+    end
+    editor_cmd = editor_cmd or "${EDITOR:-vim} %s"
 
     local old_names = {}
     for _, path in ipairs(selected) do

--- a/main.lua
+++ b/main.lua
@@ -31,6 +31,38 @@ local function list_map(self, f)
     end
 end
 
+local function common_prefix(paths)
+    if #paths == 0 then
+        return ""
+    end
+    if #paths == 1 then
+        local last_slash = paths[1]:match(".*()/")
+        if last_slash then
+            return paths[1]:sub(1, last_slash - 1)
+        end
+        return paths[1]
+    end
+
+    local prefix = paths[1]
+    for i = 2, #paths do
+        local path = paths[i]
+        local j = 1
+        while j <= #prefix and j <= #path and prefix:sub(j, j) == path:sub(j, j) do
+            j = j + 1
+        end
+        prefix = prefix:sub(1, j - 1)
+        if prefix == "" then
+            return ""
+        end
+    end
+
+    local last_slash = prefix:match(".*()/")
+    if last_slash then
+        return prefix:sub(1, last_slash - 1)
+    end
+    return ""
+end
+
 local get_state = ya.sync(function(_, cmd)
     if cmd == "paste" or cmd == "link" or cmd == "hardlink" then
         local yanked = {}
@@ -68,13 +100,49 @@ local get_state = ya.sync(function(_, cmd)
                 selected = selected,
             },
         }
-    elseif cmd == "rename" and #cx.active.selected == 0 then
-        return {
-            kind = cmd,
-            value = {
-                hovered = tostring(cx.active.current.hovered.url),
-            },
-        }
+    elseif cmd == "rename" then
+        if #cx.active.selected <= 1 then
+            local hovered
+            if #cx.active.selected == 1 then
+                for _, url in pairs(cx.active.selected) do
+                    hovered = tostring(url)
+                    break
+                end
+            else
+                hovered = tostring(cx.active.current.hovered.url)
+            end
+            return {
+                kind = cmd,
+                value = {
+                    hovered = hovered,
+                },
+            }
+        else
+            local selected = {}
+            for _, url in pairs(cx.active.selected) do
+                table.insert(selected, tostring(url))
+            end
+
+            local editor_cmd = nil
+            local oe = rt and rt.opener and rt.opener.edit
+            if oe then
+                for _, rule in ipairs(oe) do
+                    if rule.block then
+                        editor_cmd = rule.run
+                        break
+                    end
+                end
+            end
+            editor_cmd = editor_cmd or "${EDITOR:-vim} %s"
+
+            return {
+                kind = "bulk_rename",
+                value = {
+                    selected = selected,
+                    editor_cmd = editor_cmd,
+                },
+            }
+        end
     elseif cmd == "chmod" then
         local selected = {}
 
@@ -195,6 +263,40 @@ local function sudo_rename(value)
     end
 end
 
+local function sudo_bulk_rename(value)
+    local selected = value.selected
+    local root = common_prefix(selected)
+    local editor_cmd = value.editor_cmd
+
+    local old_names = {}
+    for _, path in ipairs(selected) do
+        local rel = root ~= "" and path:sub(#root + 2) or path
+        table.insert(old_names, rel)
+    end
+
+    local script = {}
+    table.insert(script, "TMP=$(mktemp)")
+    table.insert(script, 'trap "rm -f $TMP" EXIT')
+    table.insert(script, "cat > \"$TMP\" << 'EOF_SUDO_YAZI'")
+    for _, name in ipairs(old_names) do
+        table.insert(script, name)
+    end
+    table.insert(script, "EOF_SUDO_YAZI")
+    local editor_line = editor_cmd:gsub("%%s", '"$TMP"')
+    table.insert(script, editor_line)
+
+    local nu_cmd = sudo_cmd()
+    extend_list(nu_cmd, { "nu", fs, "bulk-rename", "--root", root, "--tmp", "$TMP" })
+    extend_iter(nu_cmd, list_map(selected, ya.quote))
+    table.insert(script, table.concat(nu_cmd, " "))
+
+    ya.emit("shell", {
+        table.concat(script, "\n"),
+        block = true,
+        confirm = true,
+    })
+end
+
 local function sudo_remove(value)
     local args = sudo_cmd()
 
@@ -243,6 +345,8 @@ return {
             sudo_remove(state.value)
         elseif state.kind == "rename" then
             sudo_rename(state.value)
+        elseif state.kind == "bulk_rename" then
+            sudo_bulk_rename(state.value)
         elseif state.kind == "chmod" then
             sudo_chmod(state.value)
         end

--- a/main.lua
+++ b/main.lua
@@ -265,33 +265,11 @@ local function sudo_bulk_rename(value)
     end
     editor_cmd = editor_cmd or "${EDITOR:-vim} %s"
 
-    local old_names = {}
-    for _, path in ipairs(selected) do
-        local rel = root ~= "" and path:sub(#root + 2) or path
-        table.insert(old_names, rel)
-    end
+    local editor_escaped = editor_cmd:gsub("%%s", "%%%%s")
 
-    local script = {}
-    table.insert(script, "TMP=$(mktemp)")
-    table.insert(script, 'trap "rm -f $TMP" EXIT')
-    table.insert(script, "cat > \"$TMP\" << 'EOF_SUDO_YAZI'")
-    for _, name in ipairs(old_names) do
-        table.insert(script, name)
-    end
-    table.insert(script, "EOF_SUDO_YAZI")
-    local editor_line = editor_cmd:gsub("%%s", '"$TMP"')
-    table.insert(script, editor_line)
-
-    local nu_cmd = sudo_cmd()
-    extend_list(nu_cmd, { "nu", fs, "bulk-rename", "--root", root, "--tmp", "$TMP" })
-    extend_iter(nu_cmd, list_map(selected, ya.quote))
-    table.insert(script, table.concat(nu_cmd, " "))
-
-    ya.emit("shell", {
-        table.concat(script, "\n"),
-        block = true,
-        confirm = true,
-    })
+    local args = { "nu", fs, "bulk-rename", "--root", root, "--editor-cmd", ya.quote(editor_escaped) }
+    extend_iter(args, list_map(selected, ya.quote))
+    execute(args)
 end
 
 local function sudo_remove(value)

--- a/main.lua
+++ b/main.lua
@@ -63,33 +63,6 @@ local function common_prefix(paths)
     return ""
 end
 
-local function read_opener_editor()
-    local config_home = os.getenv("YAZI_CONFIG_HOME")
-        or (os.getenv("XDG_CONFIG_HOME") or os.getenv("HOME") .. "/.config") .. "/yazi"
-    local f = io.open(config_home .. "/yazi.toml", "r")
-    if not f then
-        return "${EDITOR:-vim} %s"
-    end
-    local content = f:read("*a")
-    f:close()
-
-    local opener_start = content:find("%[opener%]")
-    if not opener_start then
-        return "${EDITOR:-vim} %s"
-    end
-
-    local next_section = content:find("\n%[%w+%]", opener_start)
-    local section = next_section and content:sub(opener_start, next_section - 1) or content:sub(opener_start)
-
-    local edit_pos = section:find("edit%s*=%s*%[")
-    if not edit_pos then
-        return "${EDITOR:-vim} %s"
-    end
-
-    return section:match("run%s*=%s*\"([^\"]*)\"", edit_pos)
-        or "${EDITOR:-vim} %s"
-end
-
 local get_state = ya.sync(function(_, cmd)
     if cmd == "paste" or cmd == "link" or cmd == "hardlink" then
         local yanked = {}
@@ -150,7 +123,17 @@ local get_state = ya.sync(function(_, cmd)
                 table.insert(selected, tostring(url))
             end
 
-            local editor_cmd = read_opener_editor()
+            local editor_cmd = nil
+            local oe = rt and rt.opener and rt.opener.edit
+            if oe then
+                for _, rule in ipairs(oe) do
+                    if rule.block then
+                        editor_cmd = rule.run
+                        break
+                    end
+                end
+            end
+            editor_cmd = editor_cmd or "${EDITOR:-vim} %s"
 
             return {
                 kind = "bulk_rename",

--- a/main.lua
+++ b/main.lua
@@ -63,6 +63,33 @@ local function common_prefix(paths)
     return ""
 end
 
+local function read_opener_editor()
+    local config_home = os.getenv("YAZI_CONFIG_HOME")
+        or (os.getenv("XDG_CONFIG_HOME") or os.getenv("HOME") .. "/.config") .. "/yazi"
+    local f = io.open(config_home .. "/yazi.toml", "r")
+    if not f then
+        return "${EDITOR:-vim} %s"
+    end
+    local content = f:read("*a")
+    f:close()
+
+    local opener_start = content:find("%[opener%]")
+    if not opener_start then
+        return "${EDITOR:-vim} %s"
+    end
+
+    local next_section = content:find("\n%[%w+%]", opener_start)
+    local section = next_section and content:sub(opener_start, next_section - 1) or content:sub(opener_start)
+
+    local edit_pos = section:find("edit%s*=%s*%[")
+    if not edit_pos then
+        return "${EDITOR:-vim} %s"
+    end
+
+    return section:match("run%s*=%s*\"([^\"]*)\"", edit_pos)
+        or "${EDITOR:-vim} %s"
+end
+
 local get_state = ya.sync(function(_, cmd)
     if cmd == "paste" or cmd == "link" or cmd == "hardlink" then
         local yanked = {}
@@ -123,17 +150,7 @@ local get_state = ya.sync(function(_, cmd)
                 table.insert(selected, tostring(url))
             end
 
-            local editor_cmd = nil
-            local oe = rt and rt.opener and rt.opener.edit
-            if oe then
-                for _, rule in ipairs(oe) do
-                    if rule.block then
-                        editor_cmd = rule.run
-                        break
-                    end
-                end
-            end
-            editor_cmd = editor_cmd or "${EDITOR:-vim} %s"
+            local editor_cmd = read_opener_editor()
 
             return {
                 kind = "bulk_rename",


### PR DESCRIPTION
Inspired by the bulk_rename mechanism in Yazi itself. When 2 or more files are selected, a temp file with relative paths is created, the configured editor (via rt.opener.edit) is launched, then fs.nu runs sudo mv for each modified line.

- main.lua: common_prefix() helper, opener reading, shell script construction, bulk_rename dispatch
- fs.nu: new `main bulk-rename` command for the rename logic